### PR TITLE
Manages splunk config file contents directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ not configured in pillar, the formula will fail.
 
 ### (Windows) splunkforwarder:lookup:deploymentclient
 
-This parameter is a map containing the `source` and `source_hash` of the
-deploymentclient.conf file.
+This parameter is a map containing the `client_name` and `target_uri` keys.
+`client_name` is a string that identifies the client environment to Splunk.
+`target_uri` is the fqdn:port of the Splunk collector.
 
 >**Required**: `True`
 
@@ -37,25 +38,28 @@ deploymentclient.conf file.
 splunkforwarder:
   lookup:
     deploymentclient:
-      source: https://path/to/my/deploymentclient.conf
-      source_hash: https://path/to/my/deploymentclient.conf.HASH
+      client_name: splunk-uf-windows-srv
+      target_uri: 'hostname.domainname:9098'
 ```
 
 ### (Windows) splunkforwarder:lookup:log_local
 
-This parameter is a map containing the `source` and `source_hash` of the
-log-local.cfg file.
+This parameter is a map with a `contents` key that contains the contents of the
+`log-local.cfg` file. The `log-local.cfg` contains information on what logs
+will be forwarded to the Splunk collector.
 
->**Required**: `True`
+>**Required**: `False`
+>
+>**Default**: _See example below_
 
 **Example**:
 
 ```yaml
-splunkforwarder:
-  lookup:
-    log_local:
-      source: https://path/to/my/log-local.cfg
-      source_hash: https://path/to/my/log-local.cfg.HASH
+log_local:
+  contents: |
+      category.StatusMgr=WARN
+      category.TcpOutputProc=WARN
+      category.FilesystemChangeWatcher=ERROR
 ```
 
 ### (Windows) splunkforwarder:lookup:package
@@ -114,8 +118,9 @@ splunkforwarder:
 
 ### (Linux) splunkforwarder:lookup:deploymentclient
 
-This parameter is a map containing the `source` and `source_hash` of the
-deploymentclient.conf file.
+This parameter is a map containing the `client_name` and `target_uri` keys.
+`client_name` is a string that identifies the client environment to Splunk.
+`target_uri` is the fqdn:port of the Splunk collector.
 
 >**Required**: `True`
 
@@ -125,25 +130,28 @@ deploymentclient.conf file.
 splunkforwarder:
   lookup:
     deploymentclient:
-      source: https://path/to/my/deploymentclient.conf
-      source_hash: https://path/to/my/deploymentclient.conf.HASH
+      client_name: splunk-uf-windows-srv
+      target_uri: 'hostname.domainname:9098'
 ```
 
 ### (Linux) splunkforwarder:lookup:log_local
 
-This parameter is a map containing the `source` and `source_hash` of the
-log-local.cfg file.
+This parameter is a map with a `contents` key that contains the contents of the
+`log-local.cfg` file. The `log-local.cfg` contains information on what logs
+will be forwarded to the Splunk collector.
 
->**Required**: `True`
+>**Required**: `False`
+>
+>**Default**: _See example below_
 
 **Example**:
 
 ```yaml
-splunkforwarder:
-  lookup:
-    log_local:
-      source: https://path/to/my/log-local.cfg
-      source_hash: https://path/to/my/log-local.cfg.HASH
+log_local:
+  contents: |
+      category.StatusMgr=WARN
+      category.TcpOutputProc=WARN
+      category.FilesystemChangeWatcher=ERROR
 ```
 
 ### (Linux) splunkforwarder:lookup:package

--- a/pillar.example
+++ b/pillar.example
@@ -4,25 +4,29 @@ splunkforwarder:
 
     ##############################################################
     # WINDOWS: Required parameters for the splunkforwarder-formula
+    # Uncomment and set the required parameters, or the formula
+    # will fail.
     ##############################################################
 
     # deploymentclient.conf contains the information necessary for connecting
-    # to the splunk server. specify valid URIs for the `source` and
-    # `source_hash`, or the splunkforwarder formula will fail
-    deploymentclient:
-      source: https://path/to/my/deploymentclient.conf
-      source_hash: https://path/to/my/deploymentclient.conf.HASH
-
-    # log-local.cfg contains information on what logs will be forwarded to the
-    # splunk server. specify valid URIs for the `source` and `source_hash`, or
-    # the splunkforwarder formula will fail
-    log_local:
-      source: https://path/to/my/log-local.cfg
-      source_hash: https://path/to/my/log-local.cfg.HASH
+    # to the splunk server.
+    # deploymentclient:client_name is an identifier for the client environment
+    # deploymentclient:target_uri is is the fqdn:port of the splunk collector
+    #deploymentclient:
+      #client_name: splunk-uf-windows-srv
+      #target_uri: 'hostname.domainname:9098'
 
     ##############################################################
     # WINDOWS: Optional parameters for the splunkforwarder-formula
     ##############################################################
+
+    # log-local.cfg contains information on what logs will be forwarded to the
+    # splunk server.
+    #log_local:
+      #contents: |
+          #category.StatusMgr=WARN
+          #category.TcpOutputProc=WARN
+          #category.FilesystemChangeWatcher=ERROR
 
     # `package` is the name of the winrepo package containing the
     # splunkforwarder
@@ -34,27 +38,32 @@ splunkforwarder:
 
     ##############################################################
     # LINUX: Required parameters for the splunkforwarder-formula
+    # Uncomment and set the required parameters, or the formula
+    # will fail.
     ##############################################################
 
     # package_url is the URL to the splunkforwarder RPM.
-    package_url: https://path/to/my/splunkforwarder.rpm
+    #package_url: https://path/to/my/splunkforwarder.rpm
 
     # deploymentclient.conf contains the information necessary for connecting
     # to the splunk server.
-    deploymentclient:
-      source: https://path/to/my/deploymentclient.conf
-      source_hash: https://path/to/my/deploymentclient.conf.HASH
-
-    # log-local.cfg contains information on what logs will be forwarded to the
-    # splunk server.
-    log_local:
-      source: https://path/to/my/log-local.cfg
-      source_hash: https://path/to/my/log-local.cfg.HASH
-
+    # client_name is an identifier for the client system or environment
+    # target_uri is is the fqdn:port of the splunk collector
+    #deploymentclient:
+      #client_name: splunk-uf-linux-srv
+      #target_uri: 'hostname.domainname:9098'
 
     ##############################################################
     # LINUX: Optional parameters for the splunkforwarder-formula
     ##############################################################
+
+    # log-local.cfg contains information on what logs will be forwarded to the
+    # splunk server.
+    #log_local:
+      #contents: |
+          #category.StatusMgr=WARN
+          #category.TcpOutputProc=WARN
+          #category.FilesystemChangeWatcher=ERROR
 
     # list of ports to open outbound for splunk communication
     #client_out_ports:

--- a/splunkforwarder/elx/init.sls
+++ b/splunkforwarder/elx/init.sls
@@ -36,22 +36,27 @@ Install Splunk Package:
 Install Client Log Config File:
   file.managed:
     - name: {{ splunkforwarder.log_local.conf }}
-    - source: {{ splunkforwarder.log_local.source }}
-    - source_hash: {{ splunkforwarder.log_local.source_hash }}
     - user: root
     - group: root
     - mode: 0600
+    - contents: |
+        {{ splunkforwarder.log_local.contents | indent(8) }}
     - require:
       - pkg: Install Splunk Package
 
 Install Client Agent Config File:
   file.managed:
     - name: {{ splunkforwarder.deploymentclient.conf }}
-    - source: {{ splunkforwarder.deploymentclient.source }}
-    - source_hash: {{ splunkforwarder.deploymentclient.source_hash }}
     - user: root
     - group: root
     - mode: 0600
+    - contents: |
+        [deployment-client]
+        disabled = false
+        clientName = {{ splunkforwarder.deploymentclient.client_name }}
+
+        [target-broker:deploymentServer]
+        targetUri = {{ splunkforwarder.deploymentclient.target_uri }}
     - require:
       - pkg: Install Splunk Package
 

--- a/splunkforwarder/elx/map.jinja
+++ b/splunkforwarder/elx/map.jinja
@@ -2,17 +2,15 @@
 {%- load_yaml as defaults %}
 
 package: splunkforwarder
-package_url: ''
-package_url_hash: ''
 service: splunk
 deploymentclient:
   conf: /opt/splunkforwarder/etc/system/local/deploymentclient.conf
-  source: ''
-  source_hash: ''
 log_local:
+  contents: |
+      category.StatusMgr=WARN
+      category.TcpOutputProc=WARN
+      category.FilesystemChangeWatcher=ERROR
   conf: /opt/splunkforwarder/etc/system/local/log-local.cfg
-  source: ''
-  source_hash: ''
 client_out_ports:
   - 8089
   - 9997

--- a/splunkforwarder/windows/init.sls
+++ b/splunkforwarder/windows/init.sls
@@ -11,8 +11,13 @@ splunkforwarder-install:
 splunkforwarder-deploymentclient.conf:
   file.managed:
     - name: {{ splunkforwarder.deploymentclient.conf }}
-    - source: {{ splunkforwarder.deploymentclient.source }}
-    - source_hash: {{ splunkforwarder.deploymentclient.source_hash }}
+    - contents: |
+        [deployment-client]
+        disabled = false
+        clientName = {{ splunkforwarder.deploymentclient.client_name }}
+
+        [target-broker:deploymentServer]
+        targetUri = {{ splunkforwarder.deploymentclient.target_uri }}
     - makedirs: True
     - watch_in:
       - service: splunkforwarder-service
@@ -20,8 +25,8 @@ splunkforwarder-deploymentclient.conf:
 splunkforwarder-log-local.cfg:
   file.managed:
     - name: {{ splunkforwarder.log_local.conf }}
-    - source: {{ splunkforwarder.log_local.source }}
-    - source_hash: {{ splunkforwarder.log_local.source_hash }}
+    - contents: |
+        {{ splunkforwarder.log_local.contents | indent(8) }}
     - makedirs: True
     - watch_in:
       - service: splunkforwarder-service

--- a/splunkforwarder/windows/map.jinja
+++ b/splunkforwarder/windows/map.jinja
@@ -14,13 +14,13 @@ service: 'SplunkForwarder'
 deploymentclient:
   conf: >-
     '{{ programfiles }}\SplunkUniversalForwarder\etc\system\local\deploymentclient.conf'
-  source: ''
-  source_hash: ''
 log_local:
+  contents: |
+      category.StatusMgr=WARN
+      category.TcpOutputProc=WARN
+      category.FilesystemChangeWatcher=ERROR
   conf: >-
     '{{ programfiles }}\SplunkUniversalForwarder\etc\log-local.cfg'
-  source: ''
-  source_hash: ''
 
 {%- endload %}
 

--- a/tests/pillar/test-linux-main/main.sls
+++ b/tests/pillar/test-linux-main/main.sls
@@ -4,28 +4,32 @@ splunkforwarder:
 
     ##############################################################
     # LINUX: Required parameters for the splunkforwarder-formula
+    # Uncomment and set the required parameters, or the formula
+    # will fail.
     ##############################################################
 
     # package_url is the URL to the splunkforwarder RPM.
     package_url: https://path/to/my/splunkforwarder.rpm
-    package_url_hash: https://path/to/my/splunkforwarder.rpm.HASH
 
     # deploymentclient.conf contains the information necessary for connecting
     # to the splunk server.
+    # client_name is an identifier for the client system or environment
+    # target_uri is is the fqdn:port of the splunk collector
     deploymentclient:
-      source: 'https://path/to/my/deploymentclient.conf'
-      source_hash: 'https://path/to/my/deploymentclient.conf.HASH'
-
-    # log-local.cfg contains information on what logs will be forwarded to the
-    # splunk server.
-    log_local:
-      source: 'https://path/to/my/log-local.cfg'
-      source_hash: 'https://path/to/my/log-local.cfg.HASH'
-
+      client_name: splunk-uf-linux-srv
+      target_uri: 'hostname.domainname:9098'
 
     ##############################################################
     # LINUX: Optional parameters for the splunkforwarder-formula
     ##############################################################
+
+    # log-local.cfg contains information on what logs will be forwarded to the
+    # splunk server.
+    #log_local:
+      #contents: |
+          #category.StatusMgr=WARN
+          #category.TcpOutputProc=WARN
+          #category.FilesystemChangeWatcher=ERROR
 
     # list of ports to open outbound for splunk communication
     #client_out_ports:
@@ -34,7 +38,7 @@ splunkforwarder:
 
     # `package` is the name of the package installed by the splunkforwarder
     # RPM
-    #package: 'splunkforwarder'
+    #package: splunkforwarder
 
     # `service` is the name of the splunkforwarder service
-    #service: 'splunk'
+    #service: splunk

--- a/tests/pillar/test-windows-main/main.sls
+++ b/tests/pillar/test-windows-main/main.sls
@@ -3,35 +3,34 @@ splunkforwarder:
   lookup:
 
     ##############################################################
-    #
     # WINDOWS: Required parameters for the splunkforwarder-formula
-    #
+    # Uncomment and set the required parameters, or the formula
+    # will fail.
     ##############################################################
 
     # deploymentclient.conf contains the information necessary for connecting
-    # to the splunk server. specify valid URIs for the `source` and
-    # `source_hash`, or the splunkforwarder formula will fail
+    # to the splunk server.
+    # deploymentclient:client_name is an identifier for the client environment
+    # deploymentclient:target_uri is is the fqdn:port of the splunk collector
     deploymentclient:
-      source: https://path/to/my/deploymentclient.conf
-      source_hash: https://path/to/my/deploymentclient.conf.HASH
+      client_name: splunk-uf-windows-srv
+      target_uri: 'hostname.domainname:9098'
+
+    ##############################################################
+    # WINDOWS: Optional parameters for the splunkforwarder-formula
+    ##############################################################
 
     # log-local.cfg contains information on what logs will be forwarded to the
-    # splunk server. specify valid URIs for the `source` and `source_hash`, or
-    # the splunkforwarder formula will fail
-    log_local:
-      source: https://path/to/my/log-local.cfg
-      source_hash: https://path/to/my/log-local.cfg.HASH
-
-
-    ##############################################################
-    #
-    # WINDOWS: Optional parameters for the splunkforwarder-formula
-    #
-    ##############################################################
+    # splunk server.
+    #log_local:
+      #contents: |
+          #category.StatusMgr=WARN
+          #category.TcpOutputProc=WARN
+          #category.FilesystemChangeWatcher=ERROR
 
     # `package` is the name of the winrepo package containing the
     # splunkforwarder
-    #package: 'splunkforwarder'
+    #package: splunkforwarder
 
     # `service` is the name of the splunkforwarder service
-    #service: 'SplunkForwarder'
+    #service: SplunkForwarder


### PR DESCRIPTION
This eliminates the need to host static splunk config files,
setting the stage for allowing users to inject their requirements
for splunk log collection.
