### PR TITLE
Add branching-logic for firewalld

### DIFF
--- a/splunkforwarder/elx/init.sls
+++ b/splunkforwarder/elx/init.sls
@@ -12,11 +12,17 @@
 
 {%- for port in splunkforwarder.client_out_ports %}
   {%- if salt.grains.get('osmajorrelease') == '7'%}
+    {%- set FwZone = salt.firewalld.default_zone() %}
 Allow Splunk Mgmt Outbound Port {{ port }}:
-  cmd.run:
-    - name: 'printf "\nchanged=no comment=''No firewalld handler currently available to handle port {{ port }} exception.''\n"'
-    - cwd: /root
-    - stateful: True
+  module.run:
+    - name: 'firewalld.add_port'
+    - zone: '{{ FwZone }}'
+    - port: '{{ port }}/tcp'
+    - permanent: True
+
+Reload firewalld for Outbound Port {{ port }}:
+  module.run:
+    - name: firewalld.reload_rules
 
   {%- elif salt.grains.get('osmajorrelease') == '6'%}
 Allow Splunk Mgmt Outbound Port {{ port }}:

--- a/splunkforwarder/elx/init.sls
+++ b/splunkforwarder/elx/init.sls
@@ -11,6 +11,14 @@
 {%- from tpldir ~ '/map.jinja' import splunkforwarder with context %}
 
 {%- for port in splunkforwarder.client_out_ports %}
+  {%- if salt.grains.get('osmajorrelease') == '7'%}
+Allow Splunk Mgmt Outbound Port {{ port }}:
+  cmd.run:
+    - name: 'printf "\nchanged=no comment=''No firewalld handler currently available to handle port {{ port }} exception.''\n"'
+    - cwd: /root
+    - stateful: True
+
+  {%- elif salt.grains.get('osmajorrelease') == '6'%}
 Allow Splunk Mgmt Outbound Port {{ port }}:
   iptables.append:
     - table: filter
@@ -26,6 +34,8 @@ Allow Splunk Mgmt Outbound Port {{ port }}:
     - save: True
     - require_in:
       - file: Install Splunk Package
+  {%- else %}
+  {%- endif %}
 {%- endfor %}
 
 Install Splunk Package:


### PR DESCRIPTION
* Split elx/init.sls by salt-grain `osmajorrelease`
* Move current iptables logic to `osmajorrelease == 6` branch
* Add logic to `osmajorrelease == 7` branch to use firewalld
  - Handling is sub-optimal: firewalld is restarted for each attempted port-add action. While sub-optimal, this method requires the least-extensive rewriting of the state

