### PR TITLE
Ignores bad exits from clone-prep-clear-config

### DIFF
--- a/splunkforwarder/windows/init.sls
+++ b/splunkforwarder/windows/init.sls
@@ -42,7 +42,7 @@ splunkforwarder-service-stop:
 
 splunkforwarder-clone-prep-clear-config:
   cmd.run:
-    - name: '"{{ splunkforwarder.bin_file }}" clone-prep-clear-config'
+    - name: '"{{ splunkforwarder.bin_file }}" clone-prep-clear-config || exit /B 0'
     - watch_in:
       - service: splunkforwarder-service-start
 


### PR DESCRIPTION
splunk.exe exits non-zero (`23`, in this case) even when the command
does exactly what it is supposed to do. This patch prevents the
state from failing just because of this splunk quirk.

Fixes #8