### PR TITLE
Updates defaults to support splunkforwarder v9 and precreate splunk user

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,54 +1,58 @@
+dist: focal
 language: python
-sudo: true
+sudo: required
 env:
   global:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
     - SEGFAULT_SIGNALS=all
     - SALT_STATE=splunkforwarder
+    - SALT_REPO_URL=https://repo.saltproject.io/py3/redhat/OS_REL/x86_64/3004.repo
   matrix:
-    - OS_VERSION=6 SALT_PILLARROOT=$TRAVIS_BUILD_DIR/tests/pillar/test-linux-main
-    # - OS_VERSION=7 SALT_PILLARROOT=$TRAVIS_BUILD_DIR/tests/pillar/test-linux-main
+    - OS_VERSION=7 SALT_PILLARROOT=$TRAVIS_BUILD_DIR/tests/pillar/test-linux-main
 
 services:
   - docker
 
 before_install:
   - sudo apt-get update
-  - |
-    echo 'DOCKER_OPTS="-H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock -s devicemapper"' | \
+  - echo 'DOCKER_OPTS="-H tcp://127.0.0.1:2375
+      -H unix:///var/run/docker.sock -s devicemapper"' |
       sudo tee /etc/default/docker > /dev/null
   - sudo service docker restart
   - sleep 5
-  - sudo docker pull centos:centos${OS_VERSION}
   - sudo docker build -t local/centos:${OS_VERSION} tests/docker/centos${OS_VERSION}
 
 install:
-  - |
-    sudo docker run --detach --privileged \
-      --volume="${TRAVIS_BUILD_DIR}":"${TRAVIS_BUILD_DIR}":ro \
-      --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro \
+  - sudo docker run --detach --privileged
+      --volume="${TRAVIS_BUILD_DIR}":"${TRAVIS_BUILD_DIR}":ro
+      --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro
       --name centos-${OS_VERSION} local/centos:${OS_VERSION} init
-  - |
-    sudo docker exec centos-${OS_VERSION} yum -y install \
-      https://repo.saltstack.com/yum/redhat/salt-repo-latest-2.el${OS_VERSION}.noarch.rpm
-  - sudo docker exec centos-${OS_VERSION} yum -y install salt-minion util-linux-ng
+  - sudo docker exec centos-${OS_VERSION} curl -sSL
+      -o /etc/yum.repos.d/salt.repo "$(
+        sed 's/OS_REL/'"${OS_VERSION}"'/' <<< ${SALT_REPO_URL}
+      )"
+  - sudo docker exec centos-${OS_VERSION} yum -y install
+      $(<${TRAVIS_BUILD_DIR}/tests/requirements.txt)
   - sudo docker exec centos-${OS_VERSION} salt-call --versions-report
+  - sudo docker exec centos-${OS_VERSION} salt-call --local
+      --retcode-passthrough
+      --file-root=$TRAVIS_BUILD_DIR
+      --pillar-root=$SALT_PILLARROOT
+      saltutil.sync_all
 
 script:
-  - |
-    sudo docker exec centos-${OS_VERSION} salt-call --local \
-      --retcode-passthrough --log-file-level debug \
-      --file-root=$TRAVIS_BUILD_DIR \
-      --pillar-root=$SALT_PILLARROOT \
-      state.show_sls \
+  - sudo docker exec centos-${OS_VERSION} salt-call --local
+      --retcode-passthrough --log-file-level debug
+      --file-root=$TRAVIS_BUILD_DIR
+      --pillar-root=$SALT_PILLARROOT
+      state.show_sls
       $SALT_STATE
-  - |
-    sudo docker exec centos-${OS_VERSION} salt-call --local \
-      --retcode-passthrough --log-file-level debug \
-      --file-root=$TRAVIS_BUILD_DIR \
-      --pillar-root=$SALT_PILLARROOT \
-      state.sls \
-      $SALT_STATE \
+  - sudo docker exec centos-${OS_VERSION} salt-call --local
+      --retcode-passthrough --log-file-level debug
+      --file-root=$TRAVIS_BUILD_DIR
+      --pillar-root=$SALT_PILLARROOT
+      state.sls
+      $SALT_STATE
       mock=True
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - SALT_REPO_URL=https://repo.saltproject.io/py3/redhat/OS_REL/x86_64/3004.repo
   matrix:
     - OS_VERSION=7 SALT_PILLARROOT=$TRAVIS_BUILD_DIR/tests/pillar/test-linux-main
+    - OS_VERSION=8 SALT_PILLARROOT=$TRAVIS_BUILD_DIR/tests/pillar/test-linux-main
 
 services:
   - docker

--- a/README.md
+++ b/README.md
@@ -235,3 +235,32 @@ splunkforwarder:
   lookup:
     service: splunk
 ```
+
+### (Linux) splunkforwarder:lookup:user
+
+The `user` is an object of attributes that configure the user for the Splunk
+Universal Forwarder.
+
+>**Required**: `False`
+>
+>**Default**:
+>
+>```yaml
+>user:
+>  name: splunk
+>  fullname: Splunk Server
+>  home: /opt/splunkforwarder
+>  shell: /bin/bash
+>```
+
+**Example**:
+
+```yaml
+splunkforwarder:
+  lookup:
+    user:
+      name: splunk
+      fullname: Splunk Server
+      home: /opt/splunkforwarder
+      shell: /bin/bash
+```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,18 @@
 version: '{branch}-{build}'
+image: Visual Studio 2019
 build: off
 environment:
   global:
     SALT_FILEROOT: '%APPVEYOR_BUILD_FOLDER%'
     SALT_STATE: splunkforwarder
-    SALT_URL: https://repo.saltstack.com/windows/Salt-Minion-2019.2.5-Py2-AMD64-Setup.exe
+    SALT_URL: https://repo.saltproject.io/windows/Salt-Minion-3004.2-1-Py3-AMD64-Setup.exe
   matrix:
     - SALT_PILLARROOT: '%APPVEYOR_BUILD_FOLDER%\tests\pillar\test-windows-main'
 
 init:
   - ps: echo $env:PILLAR_HOME
 install:
+  - ps: '[Net.ServicePointManager]::SecurityProtocol = "Tls12, Tls13"'
   - ps: |
       $null = `
         (new-object net.webclient).DownloadFile(${env:SALT_URL}, `
@@ -18,7 +20,7 @@ install:
   - ps: |
       $null = `
         Start-Process -FilePath "${env:temp}\salt-minion.exe" `
-        -ArgumentList "/S" -NoNewWindow -PassThru -Wait
+        -ArgumentList  @("/S", "/install-dir=c:\salt") -NoNewWindow -PassThru -Wait
   - ps: C:\salt\salt-call.bat --versions-report
 
 test_script:

--- a/pillar.example
+++ b/pillar.example
@@ -93,3 +93,10 @@ splunkforwarder:
 
     # `service` is the name of the splunkforwarder service
     #service: splunk
+
+    # `user` is an object of attributes used to configure the splunk user
+    #user:
+    #  name: splunk
+    #  fullname: Splunk Server
+    #  home: /opt/splunkforwarder
+    #  shell: /bin/bash

--- a/splunkforwarder/elx/init.sls
+++ b/splunkforwarder/elx/init.sls
@@ -13,30 +13,11 @@
 {%- set comment = "Connectivity for splunkforwarder" %}
 
 {%- for port in splunkforwarder.client_out_ports %}
-  {%- if salt.grains.get('osmajorrelease') == '7' %}
 Allow Splunk Mgmt Outbound Port {{ port }}:
   cmd.run:
     - name: |
         firewall-cmd --direct --add-rule ipv4 filter OUTPUT_direct 50 -p tcp -m tcp --dport={{ port }} -m comment --comment "{{ comment }}" -j ACCEPT
         firewall-cmd --permanent --direct --add-rule ipv4 filter OUTPUT_direct 50 -p tcp -m tcp --dport={{ port }} -m comment --comment "{{ comment }}" -j ACCEPT
-  {%- elif salt.grains.get('osmajorrelease') == '6' %}
-Allow Splunk Mgmt Outbound Port {{ port }}:
-  iptables.append:
-    - table: filter
-    - chain: OUTPUT
-    - jump: ACCEPT
-    - match:
-        - state
-        - comment
-    - comment: "{{ comment }}"
-    - connstate: NEW
-    - dport: {{ port }}
-    - proto: tcp
-    - save: True
-    - require_in:
-      - file: Install Splunk Package
-  {%- else %}
-  {%- endif %}
 {%- endfor %}
 
 Install Splunk Package:

--- a/splunkforwarder/elx/init.sls
+++ b/splunkforwarder/elx/init.sls
@@ -48,19 +48,20 @@ Install Splunk Package:
 Install Client Log Config File:
   file.managed:
     - name: {{ splunkforwarder.log_local.conf }}
-    - user: root
-    - group: root
+    - user: {{ splunkforwarder.user.name }}
+    - group: {{ splunkforwarder.user.name }}
     - mode: 0600
     - contents: |
         {{ splunkforwarder.log_local.contents | indent(8) }}
     - require:
       - pkg: Install Splunk Package
+      - user: Manage Splunk User
 
 Install Client Agent Config File:
   file.managed:
     - name: {{ splunkforwarder.deploymentclient.conf }}
-    - user: root
-    - group: root
+    - user: {{ splunkforwarder.user.name }}
+    - group: {{ splunkforwarder.user.name }}
     - mode: 0600
     - contents: |
         [deployment-client]
@@ -71,13 +72,14 @@ Install Client Agent Config File:
         targetUri = {{ splunkforwarder.deploymentclient.target_uri }}
     - require:
       - pkg: Install Splunk Package
+      - user: Manage Splunk User
 
 {%- if splunkforwarder.inputs.get('sections') %}
 Create Inputs Conf:
   file.managed:
     - name: {{ splunkforwarder.inputs.conf }}
-    - user: root
-    - group: root
+    - user: {{ splunkforwarder.user.name }}
+    - group: {{ splunkforwarder.user.name }}
     - mode: 0600
     - makedirs: True
     - replace: False
@@ -89,31 +91,31 @@ Configure Local Log Sources:
     - name: {{ splunkforwarder.inputs.conf }}
     - sections: {{ splunkforwarder.inputs.sections | yaml }}
     - require_in:
-      - cmd: Accept Splunk License
+      - cmd: Start Splunk Service
     - watch_in:
       - service: Ensure Splunk Service is Running
 {%- endif %}
 
-Accept Splunk License:
+Configure Splunk Agent Boot-scripts:
   cmd.run:
-    - name: {{ splunkforwarder.bin_file }} start {{ splunkforwarder.service_opts }}
+    - name: {{ splunkforwarder.bin_file }} enable boot-start {{ splunkforwarder.service_opts }}
     - require:
       - file: Install Client Log Config File
       - file: Install Client Agent Config File
-    - unless: test -f {{ splunkforwarder.cert_file }}
-
-Configure Splunk Agent Boot-scripts:
-  cmd.run:
-    - name: {{ splunkforwarder.bin_file }} enable boot-start
-    - require:
-      - cmd: Accept Splunk License
     - unless: test -f {{ splunkforwarder.service_file }}
+
+Start Splunk Service:
+  cmd.run:
+    - name: {{ splunkforwarder.bin_file }} start
+    - require:
+      - cmd: Configure Splunk Agent Boot-scripts
+    - unless: test -f {{ splunkforwarder.cert_file }}
 
 Enable Splunk Service:
   service.enabled:
     - name: {{ splunkforwarder.service }}
     - require:
-      - cmd: Configure Splunk Agent Boot-scripts
+      - cmd: Start Splunk Service
 
 Ensure Splunk Service is Running:
   service.running:
@@ -127,8 +129,8 @@ Ensure Splunk Service is Running:
 Pre-Create Splunk Log Directory:
   file.directory:
     - name: /var/log/splunk
-    - user: root
-    - group: root
+    - user: {{ splunkforwarder.user.name }}
+    - group: {{ splunkforwarder.user.name }}
     - dir_mode: 0700
     - recurse:
       - user
@@ -142,9 +144,18 @@ Create Sym-link To Splunk Log Dir:
   file.symlink:
     - name: /opt/splunkforwarder/var/log/splunk
     - target: /var/log/splunk
-    - user: root
-    - group: root
+    - user: {{ splunkforwarder.user.name }}
+    - group: {{ splunkforwarder.user.name }}
     - mode: 0700
     - makedirs: True
     - require_in:
       - pkg: Install Splunk Package
+
+Manage Splunk User:
+  user.present:
+    - name: {{ splunkforwarder.user.name }}
+    - fullname: {{ splunkforwarder.user.fullname }}
+    - home: {{ splunkforwarder.user.home }}
+    - usergroup: True
+    - require_in:
+      - file: Pre-Create Splunk Log Directory

--- a/splunkforwarder/elx/map.jinja
+++ b/splunkforwarder/elx/map.jinja
@@ -20,7 +20,7 @@ client_out_ports:
   - 9997
 cert_file: /opt/splunkforwarder/etc/auth/splunkweb/cert.pem
 bin_file: /opt/splunkforwarder/bin/splunk
-service_file: /etc/init.d/splunk
+service_file: /etc/systemd/system/SplunkForwarder.service
 
 {%- endload %}
 

--- a/splunkforwarder/elx/map.jinja
+++ b/splunkforwarder/elx/map.jinja
@@ -21,6 +21,11 @@ client_out_ports:
 cert_file: /opt/splunkforwarder/etc/auth/server.pem
 bin_file: /opt/splunkforwarder/bin/splunk
 service_file: /etc/systemd/system/SplunkForwarder.service
+user:
+  name: splunk
+  fullname: Splunk Server
+  home: /opt/splunkforwarder
+  shell: /bin/bash
 
 {%- endload %}
 

--- a/splunkforwarder/elx/map.jinja
+++ b/splunkforwarder/elx/map.jinja
@@ -18,7 +18,7 @@ inputs:
 client_out_ports:
   - 8089
   - 9997
-cert_file: /opt/splunkforwarder/etc/auth/splunkweb/cert.pem
+cert_file: /opt/splunkforwarder/etc/auth/server.pem
 bin_file: /opt/splunkforwarder/bin/splunk
 service_file: /etc/systemd/system/SplunkForwarder.service
 

--- a/tests/docker/centos6/Dockerfile
+++ b/tests/docker/centos6/Dockerfile
@@ -1,5 +1,0 @@
-FROM centos:centos6
-
-RUN yum -y install upstart; yum clean all
-
-CMD ["/bin/bash"]

--- a/tests/docker/centos8/Dockerfile
+++ b/tests/docker/centos8/Dockerfile
@@ -1,0 +1,3 @@
+FROM quay.io/centos/centos:stream8
+
+CMD ["/bin/bash"]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,2 @@
+salt-minion
+util-linux-ng


### PR DESCRIPTION
By precreating the splunk user, we can ensure that all directories and files are owned by the correct user instead of root, which makes this formula return 0 changes when run a second time.
